### PR TITLE
chore: Make JsonCodec publicly accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! [`SharedPostgresStorage`]: crate::shared::SharedPostgresStorage
 use std::{fmt::Debug, marker::PhantomData};
 
-use apalis_codec::json::JsonCodec;
+pub use apalis_codec::json::JsonCodec;
 use apalis_core::{
     backend::{Backend, BackendExt, TaskStream, codec::Codec, queue::Queue},
     features_table,


### PR DESCRIPTION
## Description

Re-exports JsonCodec
Otherwise, I would have to import JsonCodec through apalis-codec.
```
pub type MYStorage = PostgresStorage<
    FupoTask,
    apalis_postgres::CompactType,
    JsonCodec<apalis_postgres::CompactType>,
    PgNotify,
>;

static TASK_STORAGE: OnceLock<Mutex<MYStorage>> = OnceLock::new();
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring (no functional changes)

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the existing tests and they pass
- [ ] I have run `cargo fmt` and `cargo clippy`

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

Any additional information, context, or screenshots about the pull request here.